### PR TITLE
Allow single character argument list

### DIFF
--- a/src/PHP/ArgvParser.php
+++ b/src/PHP/ArgvParser.php
@@ -39,6 +39,10 @@ class PHP_ArgvParser
                     // have sub parameter
                     $configs[$matches[1]] = $argv[$index + 1];
                     $index++;
+                } elseif (strpos($matches[0], '--') === false) {
+                    for ($j = 0; $j < strlen($matches[1]); $j += 1) {
+                        $configs[$matches[1][$j]] = true;
+                    }
                 } else {
                     $configs[$matches[1]] = true;
                 }


### PR DESCRIPTION
A single character argument list like "-ok" is properly parsed as `[o => true, k => true]` instead of `[ok => true]`.
Off course behaviour of "--ok" remains unchanged.